### PR TITLE
Add the products of yecc and leex to the excluded_files list

### DIFF
--- a/src/eini.app.src
+++ b/src/eini.app.src
@@ -6,5 +6,6 @@
     {registered, []},
     {mod, {eini_app, []}},
     {licenses, ["Apache 2.0"]},
-    {links, [{"Github", "https://github.com/erlcloud/eini"}]}
+    {links, [{"Github", "https://github.com/erlcloud/eini"}]},
+    {exclude_files, ["src/eini_parser.erl", "src/eini_lexer.erl"]}
 ]}.


### PR DESCRIPTION
Finally figured out why erlcloud/erlcloud#308 was broken -- when I pushed the Hex package over here, it included the built lexer and parser (because they're source files). But these need to be _excluded_ so that they'll get built by the version of Erlang that's building everything else.
