### PR TITLE
Add support for dash ('-') in titles & keys

### DIFF
--- a/src/eini_lexer.xrl
+++ b/src/eini_lexer.xrl
@@ -20,7 +20,7 @@
 Definitions.
 
 %% Characters for keys
-K = [a-zA-Z0-9_\.]+
+K = [a-zA-Z0-9_\-\.]+
 
 %% Characters for values, printable except =, [ and ]
 %% \x3b : $;

--- a/test/eini_tests.erl
+++ b/test/eini_tests.erl
@@ -353,24 +353,24 @@ two_section_test_() ->
    fun teardown/1,
    [
     ?_assertEqual({ok, [
-                        {titleA, []},
-                        {titleB, []}
+                        {title_A, []},
+                        {'title-B', []}
                        ]},
                   parse(
-                    "[titleA]\n"
-                    "[titleB]\n"
+                    "[title_A]\n"
+                    "[title-B]\n"
                    )),
     ?_assertEqual({ok, [
-                        {titleA,
-                         [{keyA1, <<"valueA1">>}]},
-                        {titleB,
-                         [{keyB1, <<"valueB1">>}]}
+                        {'Title_A',
+                         [{'Key_A1', <<"value_A1">>}]},
+                        {'Title-B',
+                         [{'Key-B1', <<"value-B1">>}]}
                        ]},
                   parse(
-                    "[titleA]\n"
-                    "keyA1=valueA1\n"
-                    "[titleB]  \n"
-                    "keyB1=valueB1\n"
+                    "[Title_A]\n"
+                    "Key_A1=value_A1\n"
+                    "[Title-B]  \n"
+                    "Key-B1=value-B1\n"
                    ))
    ]}.
 


### PR DESCRIPTION
The dash should really be supported as a title/key part. It it a commonly used "spacer" in titles and keys, and AWS INI files already support it.

Partially deals with accense/eini#2, but I have left spaces for another day—it is not clear what the policy should be here.
