### PR TITLE
Rename covertool plugin to ‘covertool’

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,11 +26,10 @@
             {test, [
                     {eunit_opts, [{report,{eunit_surefire,[{dir,"."}]}}]}
                    ,{cover_enabled, true}
-                   ,{plugins, [rebar_covertool]}
+                   ,{plugins, [covertool]}
                    ,{covertool_eunit, ".eunit/eunit.coverage.xml"}
                    ,{deps, [
-                            {proper, {git, "https://github.com/manopapad/proper.git", {ref, "v1.2"}}},
-                            {covertool, {git, "https://github.com/idubrov/covertool.git", {branch, "master"}}}
+                            {proper, {git, "https://github.com/manopapad/proper.git", {ref, "v1.2"}}}
                            ]}
                    ]}
            ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -12,9 +12,7 @@ case erlang:function_exported(rebar3, main, 1) of
 
         %% whenever adding a new Hex package dependency, this fun should be
         %% updated
-        HexToRepo = fun(proper) -> "https://github.com/manopapad/proper.git";
-                       (covertool) -> "https://github.com/idubrov/covertool.git"
-                    end,
+        HexToRepo = fun(proper) -> "https://github.com/manopapad/proper.git" end,
 
         ConvertDep =
             fun({DepName, {git, Repo, {ref, Tag}}}) ->


### PR DESCRIPTION
* See https://github.com/covertool/covertool/issues/42.
* Also remove it from rebar 2 dep set. It’s only a plugin, only for testing. You can use it as `rebar3 as test covertool generate`.