### PR TITLE
Remove covertool from repo

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,11 +26,8 @@
             {test, [
                     {eunit_opts, [{report,{eunit_surefire,[{dir,"."}]}}]}
                    ,{cover_enabled, true}
-                   ,{plugins, [rebar_covertool]}
-                   ,{covertool_eunit, ".eunit/eunit.coverage.xml"}
                    ,{deps, [
-                            {proper, {git, "https://github.com/manopapad/proper.git", {ref, "v1.2"}}},
-                            {covertool, {git, "https://github.com/idubrov/covertool.git", {branch, "master"}}}
+                            {proper, {git, "https://github.com/manopapad/proper.git", {ref, "v1.2"}}}
                            ]}
                    ]}
            ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -12,8 +12,7 @@ case erlang:function_exported(rebar3, main, 1) of
 
         %% whenever adding a new Hex package dependency, this fun should be
         %% updated
-        HexToRepo = fun(proper) -> "https://github.com/manopapad/proper.git";
-                       (covertool) -> "https://github.com/idubrov/covertool.git"
+        HexToRepo = fun(proper) -> "https://github.com/manopapad/proper.git"
                     end,
 
         ConvertDep =


### PR DESCRIPTION
This plugin isn’t actually used by any existing process, and really only has value in the context of Jenkins/some other Cobertura processing tool, which this isn’t integrated to at all. So, just remove it.