### PR TITLE
Fix deprecated string:strip calls

### DIFF
--- a/src/eini_parser.yrl
+++ b/src/eini_parser.yrl
@@ -106,5 +106,5 @@ value_of(Token) ->
 
 -spec strip_values([TokenChars::string()]) -> Value::binary().
 strip_values(Values) ->
-  String = string:strip(string:strip(lists:flatten(Values), both, $\s), both, $\t),
+  String = string:trim(string:trim(lists:flatten(Values), both, "\s"), both, "\t"),
   list_to_binary(String).


### PR DESCRIPTION
Compiling with OTP 21 gave deprecation warnings for string:strip. Replaced the calls with string:trim.