### PR TITLE
support blank in section title

### DIFF
--- a/src/eini_parser.yrl
+++ b/src/eini_parser.yrl
@@ -23,6 +23,8 @@ Nonterminals
   sections_with_skip_lines
   section
   title_part
+  title_word
+  title_words
   title
   property_with_skip_lines
   properties property
@@ -70,7 +72,13 @@ title_part -> title blank break            : list_to_atom('$1').
 title_part -> title break skip_lines       : list_to_atom('$1').
 title_part -> title blank break skip_lines : list_to_atom('$1').
 
-title -> '[' word ']'              : value_of('$2').
+title_word -> word : value_of('$1').
+title_word -> blank : value_of('$1').
+
+title_words -> title_word : ['$1'].
+title_words -> title_word title_words : ['$1' | '$2'].
+
+title -> '[' title_words ']' : string:strip(lists:flatten('$2'), both, $\s).
 
 properties -> '$empty' : [].
 properties -> property_with_skip_lines properties : ['$1' | '$2'].

--- a/test/eini_tests.erl
+++ b/test/eini_tests.erl
@@ -138,7 +138,44 @@ one_section_title_only_test_() ->
                     "[title]  \n"
                     "\n"
                     "\n"
-                   ))
+                   )),
+    %% blank char in section title
+    ?_assertEqual({ok, [
+                        {'tit le', []}
+                       ]},
+                  parse("[tit le]")),
+    ?_assertEqual({ok, [
+                        {'tit le A', []}
+                       ]},
+                  parse("[tit le A]")),
+    ?_assertEqual({ok, [
+                        {'tit le A', []}
+                       ]},
+                  parse("[  tit le A  ]")),
+    ?_assertEqual({ok, [
+                        {'tit  le', []}
+                       ]},
+                  parse("[  tit  le]")),
+    ?_assertEqual({ok, [
+                        {'tit le', []}
+                       ]},
+                  parse("[tit le  ]")),
+    ?_assertEqual({ok, [
+                        {'tit  le', []}
+                       ]},
+                  parse("[  tit  le  ]")),
+    ?_assertEqual({ok, [
+                        {'title', []}
+                       ]},
+                  parse("[  title  ]")),
+    ?_assertEqual({ok, [
+                        {'title', []}
+                       ]},
+                  parse("[  title]")),
+    ?_assertEqual({ok, [
+                        {'title', []}
+                       ]},
+                  parse("[title  ]"))
    ]}.
 
 one_section_title_only_syntax_error_test_() ->
@@ -457,14 +494,6 @@ syntax_error_title_test_() ->
                         ";\n"
                         "; comment 2\n"
                         "  [title]")),
-    %% blank char in section title
-    ?_assertMatch({error, {syntax_error, _, _Reason}},
-                  parse(
-                    "[titleA]\n"
-                    "keyA1=valueA1\n"
-                    "[tit  leB]\n"
-                    "keyB1=valueB1\n"
-                   )),
     %% comment after title
     ?_assertMatch({error, {syntax_error, _, ["syntax error before: ", _]}},
                   parse("[title] ;comment")),


### PR DESCRIPTION
Hi guys，
AWS config delimit profile name in section title by blank, like this:

```
[profile eini]
```

so I updated eini_parser.yrl and eini_tests.erl .

Thank you.